### PR TITLE
Add option to set hours using cli

### DIFF
--- a/timetracker/cli.py
+++ b/timetracker/cli.py
@@ -41,11 +41,15 @@ def tt():
     is_flag=True,
     help='Is this day paid time off'
 )
-def load(text, config, date, pto, vacations):
+@click.option(
+    '--hours', '-h',
+    help='How long did it take?',
+)
+def load(text, config, date, pto, vacations, hours):
     """
     Load hours
     """
-    load_hours(text, config, date, pto, vacations)
+    load_hours(text, config, date, pto, vacations, hours)
 
 
 @tt.command()

--- a/timetracker/constants.py
+++ b/timetracker/constants.py
@@ -10,6 +10,6 @@ ASSIGNMENT_DROPDOWN = 'ctl00_ContentPlaceHolder_idTipoAsignacionDropDownList'
 FOCAL_DROPDOWN = 'ctl00_ContentPlaceHolder_idFocalPointClientDropDownList'
 
 LOGIN_CREDENTIALS = ['username', 'password']
-LOAD_HOURS_OPTIONS = ['project', 'assignment', 'focal', 'hours']
+LOAD_HOURS_OPTIONS = ['project', 'assignment', 'focal']
 
 WEEKDAYS = ['M', 'T', 'W', 'TH', 'F', 'S', 'SU']

--- a/timetracker/timetracker.py
+++ b/timetracker/timetracker.py
@@ -213,7 +213,7 @@ def check_required(name, available, required):
                 "'{}' missing in '{}' config option".format(value, name))
 
 
-def load_hours(text, config, date, pto, vacations):
+def load_hours(text, config, date, pto, vacations, hours):
     config = toml.load(config)
     credentials = config.get('credentials')
     options = config.get('options')
@@ -223,6 +223,13 @@ def load_hours(text, config, date, pto, vacations):
 
     if text is None and not pto and not vacations:
         raise click.BadParameter("You need to specify what you did with --text (-t)")
+
+    if hours is None:
+        hours = options.get('hours')
+
+    if hours is None:
+        raise click.BadParameter("You need to specify hours amount with --hours (-h) or using hours options in config.toml")
+
 
     if pto:
         options['project'] = 'BairesDev - Absence'
@@ -262,7 +269,7 @@ def load_hours(text, config, date, pto, vacations):
         'assignment': assignment_option,
         'text': text,
         'date': date,
-        'hours': options.get('hours')
+        'hours': hours
     }
 
     if not pto and not vacations:


### PR DESCRIPTION
Allow user to set or override hours worked on loading times:

Eg:
```shellscript
tt load -t 'Add option to set hours using cli' -h 0.5
```